### PR TITLE
fix(node): Fixing typo: cho -> echo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"setup-app": "yarn",
-		"setup-server": "cho \"Download Golang dependencies...\" && go mod download",
+		"setup-server": "echo \"Download Golang dependencies...\" && go mod download",
 		"setup-full": "yarn && yarn setup-server",
 		"upgrade-app": "yarn-upgrade-all && yarn upgrade",
 		"upgrade-server": "echo \"Update Golang dependencies...\" && go get -u ./...",


### PR DESCRIPTION
There's a bug when running the `yarn setup-full` command, this is due to the 'e' missing from the echo command:

```
$ yarn && yarn setup-server
[1/4] 🔍  Resolving packages...
success Already up-to-date.
$ cho "Download Golang dependencies..." && go mod download
/bin/sh: cho: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 127.
```

Very simple change just to add that 'e' back in.